### PR TITLE
PHP 8 migration

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,27 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '7.4', '8.0', '8.1' ]
+        include:
+          - php-version: '8.1'
+            coverage: true
+
+    steps:
+      - name: CI
+        uses: oat-sa/tao-extension-ci-action@v1
+        with:
+          php: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,34 @@
 {
-	"name": "oat-sa/extension-parcc-tei",
-		"description" : "",
-		"type" : "tao-extension",
-		"authors" : [
-		{
-			"name": "Open Assessment Technologies"
-		}],
-		"keywords" : [
-			"tao",
-		"computer-based-assessment"
-			],
-		"homepage" : "http://www.taotesting.com",
-		"license" : [
-			"PARCC"
-			],
-		"extra" : {
-			"tao-extension-name" : "parccTei"
-		},
-		"minimum-stability" : "dev",
-		"require": {
-			"oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-            "oat-sa/generis" : ">=14.0.0",
-            "oat-sa/extension-tao-xmledit-responseprocessing" : ">=2.0.0",
-            "oat-sa/extension-tao-itemqti-pci" : ">=7.0.0",
-            "oat-sa/extension-tao-itemqti" : ">=27.0.0"
-        },
-		"autoload" : {
-			"psr-4" : {
-				"oat\\parccTei\\" : ""
-			}
-		}
+    "name": "oat-sa/extension-parcc-tei",
+    "description": "",
+    "type": "tao-extension",
+    "authors": [
+        {
+            "name": "Open Assessment Technologies"
+        }
+    ],
+    "keywords": [
+        "tao",
+        "computer-based-assessment"
+    ],
+    "homepage": "http://www.taotesting.com",
+    "license": [
+        "PARCC"
+    ],
+    "extra": {
+        "tao-extension-name": "parccTei"
+    },
+    "minimum-stability": "dev",
+    "require": {
+        "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
+        "oat-sa/generis": ">=15.22",
+        "oat-sa/extension-tao-xmledit-responseprocessing": ">=2.0.0",
+        "oat-sa/extension-tao-itemqti-pci": ">=7.0.0",
+        "oat-sa/extension-tao-itemqti": ">=27.0.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "oat\\parccTei\\": ""
+        }
+    }
 }


### PR DESCRIPTION
[ADF-1097](https://oat-sa.atlassian.net/browse/ADF-1097)
[ADF-1087](https://oat-sa.atlassian.net/browse/ADF-1087)
[ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

## Goal
Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.