### PR TITLE
Feat/ADF-1416/Update node version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     "minimum-stability": "dev",
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.22",
+        "oat-sa/generis": ">=15.24",
         "oat-sa/extension-tao-xmledit-responseprocessing": ">=2.0.0",
-        "oat-sa/extension-tao-itemqti-pci": ">=7.0.0",
-        "oat-sa/extension-tao-itemqti": ">=27.0.0"
+        "oat-sa/extension-tao-itemqti-pci": ">=8.7.2",
+        "oat-sa/extension-tao-itemqti": ">=30.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1416

### Summary

Align dependencies to make sure the extension is compatible with Node 14+

**BREAKING CHANGE**
- The extension now requires Node.js 14.17+
- Replace Node-Sass with Dart-Sass

### Details

Minimal requirement:
- taoCore >= `53.0.0`
- taoQtiItem >= `30.0.0`
- pciQtiItem >= `8.7.2`