### PR TITLE
fix: existing response conditions removal

### DIFF
--- a/views/js/pciCreator/helper/responseCondition.js
+++ b/views/js/pciCreator/helper/responseCondition.js
@@ -24,15 +24,15 @@ define(['lodash', 'jquery', 'taoQtiItem/qtiCreator/helper/xmlRenderer'], functio
         var rp = item.responseProcessing;
         var renderedRp = rp.render(xmlRenderer.get()) || '<responseProcessing template=\"EMPTY\"/>';
         var $rpXml = $($.parseXML(renderedRp));
-        var rcXml = $.parseXML(newResponseConditionXml);
-        var newRc = $rpXml[0].importNode(rcXml.documentElement, true);
+        var newRcXml = $.parseXML(newResponseConditionXml);
+        var newRc = $rpXml[0].importNode(newRcXml.documentElement, true);
         var responseIdentifier = interaction.attr('responseIdentifier');
         var responseDeclaration = interaction.getResponseDeclaration();
-        var $respVar = $(rcXml).find('variable[identifier="'+responseIdentifier+'"]');
+        var $newRespVar = $(newRcXml).find('variable[identifier="'+responseIdentifier+'"]');
 
         //prepare replacement criteria
         criteria = _.defaults(criteria || {}, {
-            responseIdentifierCount : $respVar.length
+            responseIdentifierCount : $newRespVar.length
         });
 
         if($rpXml.length){
@@ -46,15 +46,17 @@ define(['lodash', 'jquery', 'taoQtiItem/qtiCreator/helper/xmlRenderer'], functio
 
             }else{
                 //if it is not a standard template, replace its rc with the new one
-                if($respVar.length === criteria.responseIdentifierCount){
+                if($newRespVar.length === criteria.responseIdentifierCount){
+                    var $existingVar = $rpXml.find('variable[identifier="' + responseIdentifier + '"]');
+                    var $existingRespCond = $existingVar.closest('responseCondition');
 
-                    //remove old node
-                    var $respCond = $respVar.parents('responseCondition');
-                    $respCond[0].parentNode.removeChild($respCond[0]);
+                    // Remove old node
+                    if($existingRespCond.length) {
+                        $existingRespCond.remove();
+                    }
 
-                    //append the new one
+                    // Append the new one
                     $rpXml[0].documentElement.appendChild(newRc);
-
                 }else{
                     throw new Error('Unexpected number of rc found');
                 }


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-4425

## What's Changed
- Fixed selector to target an old node when do a replace

https://github.com/user-attachments/assets/7c97bf27-c5d2-40fe-a11c-3d4b776169ee


- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## How to test
- Create an item
- Add a Fractions PCI
- Check "Edit Processing Rule" in response properties
- Delete the PCI
- Re-add a Fractions PCI again
- Check "Edit Processing Rule" in response properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response condition handling to ensure proper parsing, removal, and replacement during updates for more reliable condition management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->